### PR TITLE
Bump the safety thresholds for refusing the bulk delete/update records.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,10 @@ providers:
   cloudflare:
     class: octodns.provider.cloudflare.CloudflareProvider
     token: env/CLOUDFLARE_API_TOKEN
+    # Importing a domain will often delete/update many, so better to have good experience.
+    # TODO: Revisit if any apps become high-stakes.
+    update_pcent_threshold: 0.95
+    delete_pcent_threshold: 0.95
 
 zones:
   g0v.network.:


### PR DESCRIPTION
Re-ticketed from https://github.com/g0v-network/domains/pull/11

Merge failed due to 92% of g0teborg.se records being deleted on initial import, whereas default threshold is 30%.