### PR TITLE
Create link.g0v.network.yaml

### DIFF
--- a/g0v.network.domain/link.g0v.network.yaml
+++ b/g0v.network.domain/link.g0v.network.yaml
@@ -1,0 +1,9 @@
+link:
+  - type: A
+    octodns:
+      cloudflare:
+        proxied: true
+    value: 52.72.49.79
+    metdata:
+      description: Link shortener via Rebrandly
+      maintainer: patcon


### PR DESCRIPTION
Rebrandly is a service for managing shortlinks. Shortlinks are great for community stuff, as it makes it easier to communicate and remember all the important places by a shortlink keyword.

Rebrandly is free to up to 500 shortlinks. It's easy to swap out as that limit is approached, in favour of an open source thing.

I'd like to use shortlinks for the Conversa Polis User Croup call link, so that the tool beneath can be swapped out without updating docs. For e.g., we're currently using https://meet.jit.si/pol.is, but maybe we want to start using https://meet.jit.si/conversa-calls (any room on same service), or GatherTown (another service completely)

For now, these links will be changed directly in rebrandly. I've added login credentials in this doc as a temporary measure:
https://docs.google.com/document/d/1ILt_Tjc2ZutVS9rkO2k7Xmr2t5o5o6WWxQmzSvhYx9w/edit

## Future

- Create a new repo with a CSV of shortlinks like https://link.hypha.coop/shortlinks
- Set up GitHub Actions continuous integration in that repo to auto-update Rebrandly from the CSV, so no one needs to log in, and it's more transparent. This small CLI tool can be used: https://github.com/hyphacoop/spreadsheet2shortlinks