### PR TITLE
Create an email alias for platform.rebrandly@g0v.network

### DIFF
--- a/g0v.network.domain/g0v.network.yaml
+++ b/g0v.network.domain/g0v.network.yaml
@@ -25,6 +25,9 @@
       - forward-email=nyctraining:darshana@dznarayanan.com
       - forward-email=nyctraining:cs@compositescollective.com
       - forward-email=nyctraining:devinbalkind@gmail.com
+      
+      # platform.rebrandly@g0v.network
+      - forward-email=platform.rebrandly:patrick.c.connolly@gmail.com
   - type: A
     value: 162.247.75.222
     octodns:


### PR DESCRIPTION
In the interest of detaching the shortlink service from my personal stuff, I'd like to create a new email alias for this service. Re: https://github.com/g0v-network/domains/pull/26

I figured having an alias specifically for the tool/platform (instead of platforms@ or webadmin@ would make it more transparent where things were sending, without tediously logging into accounts or keeping some doc up-to-date)

I'll update the credentials in the password doc :lock: https://link.g0v.network/passwords when this is done :)