### PR TITLE
Create housing.t0ronto.ca.yml

### DIFF
--- a/t0ronto.ca.domain/housing.t0ronto.ca.yml
+++ b/t0ronto.ca.domain/housing.t0ronto.ca.yml
@@ -1,0 +1,12 @@
+---
+# Prior subdomain for WIP website: https://mchc.jrootham.ca/
+housing:
+  - type: A
+    octodns:
+      cloudflare:
+        proxied: true
+    value: 199.103.63.49
+    metdata:
+      repository: null
+      maintainer:
+        - jrootham


### PR DESCRIPTION
Staging website for humble beginnings of the MCHC website (More Co-operative Housing Collective).

Current location: https://mchc.jrootham.ca/

Main online presence right now: https://twitter.com/morecoophousing

cc: @jrootham