### PR TITLE
Add MX mail record for mchc.g0v.ca email forwarding

### DIFF
--- a/g0v.ca.domain/g0v.ca.yaml
+++ b/g0v.ca.domain/g0v.ca.yaml
@@ -5,6 +5,6 @@
       # Who has admin for this domain
       - admin=patcon
       # Used for 301 redirect service below
-      - 301 https://g0v.asia/
+      - 301 https://g0v.tw/intl/en/
   - type: ALIAS
     value: 301.ronny.tw.

--- a/g0v.ca.domain/g0v.ca.yaml
+++ b/g0v.ca.domain/g0v.ca.yaml
@@ -5,6 +5,6 @@
       # Who has admin for this domain
       - admin=patcon
       # Used for 301 redirect service below
-      - 301 https://g0v.tw/
+      - 301 https://g0v.asia/
   - type: ALIAS
     value: 301.ronny.tw.

--- a/g0v.ca.domain/mchc.g0v.ca.yaml
+++ b/g0v.ca.domain/mchc.g0v.ca.yaml
@@ -1,5 +1,5 @@
 ---
-'':
+mchc:
   - type: MX
     values:
       # Allow use of forwardemail.net

--- a/g0v.ca.domain/mchc.g0v.ca.yaml
+++ b/g0v.ca.domain/mchc.g0v.ca.yaml
@@ -18,4 +18,4 @@ mchc:
       # See: MX record above
 
       # platform.rebrandly@mchc.g0v.ca
-      - forward-email=platform.rebrandly:patrick.c.connolly@gmail.com
+      - forward-email=platform.rebrandly:patrick.c.connolly+mchc@gmail.com

--- a/g0v.ca.domain/mchc.g0v.ca.yaml
+++ b/g0v.ca.domain/mchc.g0v.ca.yaml
@@ -1,0 +1,21 @@
+---
+'':
+  - type: MX
+    values:
+      # Allow use of forwardemail.net
+      # See: https://forwardemail.net/en/faq#how-do-i-get-started-and-set-up-email-forwarding
+      - exchange: mx1.forwardemail.net.
+        preference: 10
+      - exchange: mx2.forwardemail.net.
+        preference: 10
+
+  - type: TXT
+    values:
+      # Who has admin for this domain
+      - admin=patcon
+
+      # Email forwarding via forwardemail.net
+      # See: MX record above
+
+      # platform.rebrandly@mchc.g0v.ca
+      - forward-email=platform.rebrandly:patrick.c.connolly@gmail.com


### PR DESCRIPTION
 Needed to sign up for rebrandly email account, so that we can set up link shortener.