### PR TITLE
Disable Cloudflare proxying on link.mchc.g0v.ca

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -22,9 +22,12 @@ You'll mostly wish to use these common types:
 - `MX`: used to setting up email addresses
 - `TXT`: holds arbitrary text data
 
-Both `A` and `CNAME` records can be proxied with Cloudflare, if specified as below. ([Cloudflare docs][])
+Both `A` and `CNAME` records can be proxied with Cloudflare, if specified as below.
+This is most convenient for `domain.com` and `sub.domain.com`, but for second-level subdomains like `2nd.sub.domain.com`, you're likely to hit issues.
+([Cloudflare docs][]. [General docs][2nd-level-subdomain].)
 
    [Cloudflare docs]: https://support.cloudflare.com/hc/en-us/articles/200169626-What-subdomains-are-appropriate-for-orange-gray-clouds-
+   [2nd-level-subdomain]: https://serverfault.com/questions/104160/wildcard-ssl-certificate-for-second-level-subdomain
 
 See the examples below to support in managing records.
 

--- a/g0v.ca.domain/link.mchc.g0v.ca.yaml
+++ b/g0v.ca.domain/link.mchc.g0v.ca.yaml
@@ -2,7 +2,9 @@ link.mchc:
   - type: A
     octodns:
       cloudflare:
-        proxied: true
+        # Beyond third-level, subdomains cannot be proxied to add SSL.
+        # See: https://community.cloudflare.com/t/redirect-third-level-domain/235899/2
+        proxied: false
     value: 52.72.49.79
     metdata:
       description: Link shortener via Rebrandly

--- a/g0v.network.domain/link.g0v.network.yaml
+++ b/g0v.network.domain/link.g0v.network.yaml
@@ -2,7 +2,9 @@ link:
   - type: A
     octodns:
       cloudflare:
-        proxied: true
+        # Beyond third-level, subdomains cannot be proxied to add SSL.
+        # See: https://community.cloudflare.com/t/redirect-third-level-domain/235899/2
+        proxied: false
     value: 52.72.49.79
     metdata:
       description: Link shortener via Rebrandly


### PR DESCRIPTION
With proxying, https:// shortlinks fail. The allows them to work again.

(This is only required for beyond third-level domains: e.g., for `link.sub.domain.com`, but not `link.domain.com`.)

Won't merge this until I've created some other PRs, and I created some DNS records directly in cloudflare during testing, and merging will immediately wipe them out during sync.)

## To Do
- [x] update record
- [x] create PR with manual changes so won't be deleted https://github.com/g0v-network/domains/pull/34
- [x] update docs in HOWTO.md