### PR TITLE
Added entry for ukraine.relief@g0v.network email forwarder

### DIFF
--- a/g0v.network.domain/g0v.network.yaml
+++ b/g0v.network.domain/g0v.network.yaml
@@ -19,6 +19,12 @@
       - forward-email=nobodies:cs@compositescollective.com
       - forward-email=nobodies:darshana.narayana@gmail.com
       
+      # ukraine.relief@g0v.network (and common typos, bc why not)
+      - forward-email=ukraine.relief:UkraineReliefDiscord@gmail.com
+      - forward-email=ukriane.relief:UkraineReliefDiscord@gmail.com
+      - forward-email=ukraine.releif:UkraineReliefDiscord@gmail.com
+      - forward-email=ukriane.releif:UkraineReliefDiscord@gmail.com
+      
       # nyctraining@g0v.network
       - forward-email=nyctraining:ebarry@gmail.com
       - forward-email=nyctraining:patrick.c.connolly@gmail.com


### PR DESCRIPTION
Context: https://discord.com/channels/949816700235288586/949828903642480700/950503032683122720

Entrypoint: https://link.g0v.network/walter-report-notes

Added forwarders to `UkraineReliefDiscord@gmail.com` for these incoming aliases (real one and possible typos):
- `ukraine.relief@g0v.network`
- `ukriane.relief@g0v.network`
- `ukraine.releif@g0v.network`
- `ukriane.releif@g0v.network`

Alternatives:
- we could instead use `@ukraine-relief.g0v.network` (or anything else) as the domain-level part of the forwarder
    - I can't easily do "typo-protection" in this later part of the email address/
    - I recommend using something very resistance to typos here.
    - maybe `@ua-support.g0v.network` (or another suggestion) guards us against missing things with global non-english speakers typing :)
    - having it's own domain-level portion allows for a "namespace" for other email forwarders, if ppl find value in these email aliases
        - e.g., `logistics@ukraine-relief.g0v.network` going to several ppl at first, or maybe a shared Google Group used as a collab inbox later (if that started to seem more scalable)
- other ideas? (feel free to share in #organizing [in discord](http://link.g0v.network/walter-report-discord), if you don't have a github account)