### PR TITLE
Avoid using CNAME with TXT records for redirects, which is non-standard

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,7 +23,6 @@ providers:
 
 zones:
   g0v.network.:
-    lenient: true
     sources:
       - config-files
     targets:

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -108,8 +108,6 @@ index 3d10aed..4947530 100644
      targets:
        - cloudflare
    g0v.ca.:
-+    # Allow TXT and CNAME to be created on same subdomain.
-+    lenient: true
      sources:
        - config-files
      targets:
@@ -125,8 +123,9 @@ index 0000000..7536024
 +    values:
 +      # Used for 301 redirect service below
 +      - 301 https://example.com/
-+  - type: CNAME
-+    value: 301.ronny.tw.
++  - type: A
++    # 301.ronny.tw
++    value: 52.69.187.52
 ```
 
 </details>

--- a/g0v.network.domain/explorations.conversa.g0v.network.yaml
+++ b/g0v.network.domain/explorations.conversa.g0v.network.yaml
@@ -7,5 +7,6 @@ explorations.conversa:
         - ballpointpenguin
         - dsiddarth
         - patcon
-  - type: CNAME
-    value: 301.ronny.tw.
+  - type: A
+    # 301.ronny.tw
+    value: 52.69.187.52


### PR DESCRIPTION
We were using the `lenient` flag before to suppress the warnings, but that felt like a bad idea. I think I was only opting to do it that was because I thought the non-standard use of CNAME was more self-documenting (using `301.ronny.tw` in the config and DNS records, istead of an IP address)

Bonus: now `make validate` works again.