### PR TITLE
Add email forwarding for speakers@g0v.london and hi@g0v.london

### DIFF
--- a/g0v.london.domain/g0v.london.yaml
+++ b/g0v.london.domain/g0v.london.yaml
@@ -23,9 +23,9 @@
       # - forward-email=speakers:g0v-london-speaker-booking@googlegroups.com
 
       # hi@g0v.london
-      - forward-email=speakers:aelcenganda@gmail.com
-      - forward-email=speakers:patrick.c.connolly@gmail.com
-      - forward-email=speakers:ruth.wetters@yahoo.co.uk
+      - forward-email=hi:aelcenganda@gmail.com
+      - forward-email=hi:patrick.c.connolly@gmail.com
+      - forward-email=hi:ruth.wetters@yahoo.co.uk
       # TODO: Set up a Google Group and migrate user management there instead.
       # - forward-email=speakers:g0v-london-organizing@googlegroups.com
 

--- a/g0v.london.domain/g0v.london.yaml
+++ b/g0v.london.domain/g0v.london.yaml
@@ -27,7 +27,7 @@
       - forward-email=hi:patrick.c.connolly@gmail.com
       - forward-email=hi:ruth.wetters@yahoo.co.uk
       # TODO: Set up a Google Group and migrate user management there instead.
-      # - forward-email=speakers:g0v-london-organizing@googlegroups.com
+      # - forward-email=hi:g0v-london-organizing@googlegroups.com
 
   - type: MX
     values:

--- a/g0v.london.domain/g0v.london.yaml
+++ b/g0v.london.domain/g0v.london.yaml
@@ -1,10 +1,48 @@
 ---
 '':
+  # set up 301 redirect service
+  - type: ALIAS
+    value: 301.ronny.tw.
+
   - type: TXT
     values:
       # Who has admin for this domain
       - admin=patcon
-      # Used for 301 redirect service below
+
+      # Used for 301 redirect service above
       - 301 http://www.meetup.com/g0v-london
-  - type: ALIAS
-    value: 301.ronny.tw.
+
+      # Email forwarding via forwardemail.net
+      # See: MX record below
+
+      # speakers@g0v.london
+      - forward-email=speakers:aelcenganda@gmail.com
+      - forward-email=speakers:patrick.c.connolly@gmail.com
+      - forward-email=speakers:ruth.wetters@yahoo.co.uk
+      # TODO: Set up a Google Group and migrate user management there instead.
+      # - forward-email=speakers:g0v-london-speaker-booking@googlegroups.com
+
+      # hi@g0v.london
+      - forward-email=speakers:aelcenganda@gmail.com
+      - forward-email=speakers:patrick.c.connolly@gmail.com
+      - forward-email=speakers:ruth.wetters@yahoo.co.uk
+      # TODO: Set up a Google Group and migrate user management there instead.
+      # - forward-email=speakers:g0v-london-organizing@googlegroups.com
+
+  - type: A
+    value: 162.247.75.222
+    octodns:
+      cloudflare:
+        proxied: true
+    metdata:
+      repository: https://github.com/g0v-network/g0v.network
+      maintainer:
+        - patcon
+  - type: MX
+    values:
+      # Allow use of forwardemail.net
+      # See: https://forwardemail.net/en/faq#how-do-i-get-started-and-set-up-email-forwarding
+      - exchange: mx1.forwardemail.net.
+        preference: 10
+      - exchange: mx2.forwardemail.net.
+        preference: 10

--- a/g0v.london.domain/g0v.london.yaml
+++ b/g0v.london.domain/g0v.london.yaml
@@ -29,15 +29,6 @@
       # TODO: Set up a Google Group and migrate user management there instead.
       # - forward-email=speakers:g0v-london-organizing@googlegroups.com
 
-  - type: A
-    value: 162.247.75.222
-    octodns:
-      cloudflare:
-        proxied: true
-    metdata:
-      repository: https://github.com/g0v-network/g0v.network
-      maintainer:
-        - patcon
   - type: MX
     values:
       # Allow use of forwardemail.net


### PR DESCRIPTION
Adding publicly-managed email forwarders via forwardemail.net.

For now, using speakers@ and hi@ pointing to specific email addresses, but can point these to Google Groups later :)

cc: @aelcenganda