### PR TITLE
Add forwardemail verification

### DIFF
--- a/g0v.london.domain/g0v.london.yaml
+++ b/g0v.london.domain/g0v.london.yaml
@@ -15,6 +15,9 @@
       # Email forwarding via forwardemail.net
       # See: MX record below
 
+      # ForwardEmail verification
+      - forward-email-site-verification=2qMyZtcBKB
+
       # speakers@g0v.london
       # See: https://docs.google.com/document/d/1R9PhNE3yJJgM7xlIU3ji1LyWsXzFd4GQ5euS093ptmA/edit#bookmark=kix.vnc7fne25lf4
       - forward-email=speakers:g0v-london-speakers@googlegroups.com


### PR DESCRIPTION
Need this to ensure forwardemail keeps working -- which is used to manage email forwarding via this repo. The `.london` domain as seen as high-risk and need it, which is apparently high-risk to use their service.