### PR TITLE
Add SPF anti-spoof for ForwardEmail and Gmail

### DIFF
--- a/g0v.london.domain/g0v.london.yaml
+++ b/g0v.london.domain/g0v.london.yaml
@@ -26,6 +26,8 @@
 
       # ForwardEmail verification
       - forward-email-site-verification=2qMyZtcBKB
+      # ForwardEmail anti-spoofing (incl for Gmail's "Send Mail As")
+      - v=spf1 a mx include:spf.forwardemail.net include:_spf.google.com -all
 
       # speakers@g0v.london
       # See: https://docs.google.com/document/d/1R9PhNE3yJJgM7xlIU3ji1LyWsXzFd4GQ5euS093ptmA/edit#bookmark=kix.vnc7fne25lf4


### PR DESCRIPTION
For g0v.london domain. Helps prevent our mail from going to spam.