### PR TITLE
Patch 2

### DIFF
--- a/t0ronto.ca.domain/t0ronto.ca.yaml
+++ b/t0ronto.ca.domain/t0ronto.ca.yaml
@@ -1,10 +1,16 @@
 ---
 '':
+  - type: A
+    values:
+      - 185.199.108.153
+      - 185.199.109.153
+      - 185.199.110.153
+      - 185.199.111.153
   - type: TXT
     values:
       # Who has admin for this domain
       - admin=patcon
-      # Used for 301 redirect service below
-      - 301 https://g0v.tw/intl/en/
-  - type: ALIAS
-    value: 301.ronny.tw.
+      # Used for a https://github.com/CivicTechTO/ repository custom domain for community based open data collaboration
+'www':
+  - type: CNAME
+    value: civictechto.github.io.

--- a/t0ronto.ca.domain/t0ronto.ca.yaml
+++ b/t0ronto.ca.domain/t0ronto.ca.yaml
@@ -17,3 +17,6 @@
 'www':
   - type: CNAME
     value: civictechto.github.io.
+    metdata:
+      description: GitHub page config.
+      maintainer: jordyarms

--- a/t0ronto.ca.domain/t0ronto.ca.yaml
+++ b/t0ronto.ca.domain/t0ronto.ca.yaml
@@ -6,6 +6,9 @@
       - 185.199.109.153
       - 185.199.110.153
       - 185.199.111.153
+    metdata:
+      description: GitHub page config.
+      maintainer: jordyarms
   - type: TXT
     values:
       # Who has admin for this domain


### PR DESCRIPTION
Adapted from @jordyarm's https://github.com/g0v-network/domains/pull/58, with https://github.com/g0v-network/domains/commit/76c616695af643062d8d79a9db9e5f4d8d3366e0 merged in.

> This will point the domain to github for custom domain configuration of https://github.com/CivicTechTO/toronto-community-directory the configuration is informed by https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site